### PR TITLE
minor fixes

### DIFF
--- a/ASR/ASR_Analyzer_v2.2.ps1
+++ b/ASR/ASR_Analyzer_v2.2.ps1
@@ -1,4 +1,4 @@
-﻿$RulesIds = Get-MpPreference | Select-Object -ExpandProperty AttackSurfaceReductionRules_Ids
+$RulesIds = Get-MpPreference | Select-Object -ExpandProperty AttackSurfaceReductionRules_Ids
 $RulesActions = Get-MpPreference | Select-Object -ExpandProperty AttackSurfaceReductionRules_Actions
 $RulesExclusions = Get-MpPreference | Select-Object -ExpandProperty AttackSurfaceReductionOnlyExclusions
 
@@ -30,7 +30,7 @@ $counter = 0
 
 ForEach ($j in $RulesIds){
     ## Convert GUID into Rule Name
-    If ($RulesIdsArray[$counter] -eq "56a863a9-875e-4185-98a7-b882c64b5ce5"){$RuleName = "BBlock abuse of exploited vulnerable signed drivers"}
+        If ($RulesIdsArray[$counter] -eq "56a863a9-875e-4185-98a7-b882c64b5ce5"){$RuleName = "Block abuse of exploited vulnerable signed drivers"}
     ElseIf ($RulesIdsArray[$counter] -eq "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c"){$RuleName = "Block Adobe Reader from creating child processes"}
     ElseIf ($RulesIdsArray[$counter] -eq "D4F940AB-401B-4EFC-AADC-AD5F3C50688A"){$RuleName = "Block all Office applications from creating child processes"}
     ElseIf ($RulesIdsArray[$counter] -eq "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2"){$RuleName = "Block credential stealing from the Windows local security authority subsystem (lsass.exe)"}
@@ -50,6 +50,7 @@ ForEach ($j in $RulesIds){
     If ($RulesActions[$counter] -eq 0){$RuleAction = "Disabled"}
     ElseIf ($RulesActions[$counter] -eq 1){$RuleAction = "Block"}
     ElseIf ($RulesActions[$counter] -eq 2){$RuleAction = "Audit"}
+    ElseIf ($RulesActions[$counter] -eq 6){$RuleAction = "Warn"}
     ## Output Rule Id, Name and Action
     Write-Host "=>" $RulesIdsArray[$counter] " **" $RuleName "**" "Action:"$RuleAction
     $counter++

--- a/ASR/ASR_Analyzer_v2.2.ps1
+++ b/ASR/ASR_Analyzer_v2.2.ps1
@@ -14,6 +14,7 @@ ForEach ($i in $RulesActions){
     If ($RulesActions[$counter] -eq 0){$TotalNotConfigured++}
     ElseIf ($RulesActions[$counter] -eq 1){$TotalBlock++}
     ElseIf ($RulesActions[$counter] -eq 2){$TotalAudit++}
+    ElseIf ($RulesActions[$counter] -eq 6){$TotalWarn++}
     $counter++
 }
 
@@ -21,7 +22,7 @@ Write-Host
 Write-Host ====================================== ASR Summary ======================================
 
 Write-Host "=> There's"($RulesIds).Count"rules configured"
-Write-Host "=>"$TotalNotConfigured "in Disabled Mode **" $TotalAudit "in Audit Mode **" $TotalBlock "in Block Mode"
+Write-Host "=>"$TotalNotConfigured "in Disabled Mode **" $TotalAudit "in Audit Mode **" $TotalBlock "in Block Mode **" $TotalWarn "in Warn Mode"
 
 Write-Host 
 Write-Host ====================================== ASR Rules ======================================


### PR DESCRIPTION
Added Warn as possible Configuration for ASR roles (Line 53) as requested in issue 11 (https://github.com/anthonws/MDATP_PoSh_Scripts/issues/11)
Fixed typo in line 33 (BBlock -> Block) and added some leading spaces

Reference warn: https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/enable-attack-surface-reduction?view=o365-worldwide

Tested it on my system and everything worked fine.