### PR TITLE
Fix missing variable initializer

### DIFF
--- a/ASR/ASR_Analyzer_v2.2.ps1
+++ b/ASR/ASR_Analyzer_v2.2.ps1
@@ -9,6 +9,7 @@ $counter = 0
 $TotalNotConfigured = 0
 $TotalAudit = 0
 $TotalBlock = 0
+$TotalWarn = 0
 
 ForEach ($i in $RulesActions){
     If ($RulesActions[$counter] -eq 0){$TotalNotConfigured++}


### PR DESCRIPTION
Not having this leads to errors in Powershell when executing the `$TotalWarn++` expression.